### PR TITLE
Add gossip TPU QUIC override

### DIFF
--- a/src/app/firedancer/config/default.toml
+++ b/src/app/firedancer/config/default.toml
@@ -226,6 +226,11 @@ user = ""
     # to successfully join the cluster.
     port = 8001
 
+    # Optional port to advertise in gossip for TPU QUIC traffic.
+    # When set, Firedancer will not bind this port locally but will
+    # advertise it for both TPU QUIC and TPU-forwards QUIC addresses.
+    public_tpu_quic_port = 0
+
 [rpc]
     # If nonzero, enable JSON RPC on this port, and use the next port
     # for the RPC websocket.  If zero, disable JSON RPC.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -817,7 +817,9 @@ fd_topo_initialize( config_t * config ) {
         FD_LOG_ERR(( "shred_listen_port in the config must not be greater than %hu", (ushort)(USHORT_MAX-6) ));
       tile->gossip.expected_shred_version = config->consensus.expected_shred_version;
       tile->gossip.tpu_port             = config->tiles.quic.regular_transaction_listen_port;
-      tile->gossip.tpu_quic_port        = config->tiles.quic.quic_transaction_listen_port;
+      tile->gossip.tpu_quic_port        = config->gossip.public_tpu_quic_port ?
+                                          config->gossip.public_tpu_quic_port :
+                                          config->tiles.quic.quic_transaction_listen_port;
       tile->gossip.tpu_vote_port        = config->tiles.quic.vote_transaction_listen_port;
       tile->gossip.repair_serve_port    = config->tiles.repair.repair_serve_listen_port;
       tile->gossip.entrypoints_cnt      = fd_ulong_min( config->gossip.resolved_entrypoints_cnt, FD_TOPO_GOSSIP_ENTRYPOINTS_MAX );

--- a/src/app/shared/fd_config.c
+++ b/src/app/shared/fd_config.c
@@ -120,11 +120,14 @@ fd_config_fillh( fd_config_t * config ) {
     replace( config->frankendancer.paths.authorized_voter_paths[ i ], "{name}", config->name );
   }
 
-  if( FD_UNLIKELY( config->tiles.quic.quic_transaction_listen_port!=config->tiles.quic.regular_transaction_listen_port+6 ) )
-    FD_LOG_ERR(( "configuration specifies invalid [tiles.quic.quic_transaction_listen_port] `%hu`. "
-                 "This must be 6 more than [tiles.quic.regular_transaction_listen_port] `%hu`",
-                 config->tiles.quic.quic_transaction_listen_port,
-                 config->tiles.quic.regular_transaction_listen_port ));
+  if( FD_LIKELY( config->tiles.quic.quic_transaction_listen_port ||
+                 config->tiles.quic.regular_transaction_listen_port ) ) {
+    if( FD_UNLIKELY( config->tiles.quic.quic_transaction_listen_port!=config->tiles.quic.regular_transaction_listen_port+6 ) )
+      FD_LOG_ERR(( "configuration specifies invalid [tiles.quic.quic_transaction_listen_port] `%hu`. "
+                   "This must be 6 more than [tiles.quic.regular_transaction_listen_port] `%hu`",
+                   config->tiles.quic.quic_transaction_listen_port,
+                   config->tiles.quic.regular_transaction_listen_port ));
+  }
 
   char dynamic_port_range[ 32 ];
   fd_memcpy( dynamic_port_range, config->frankendancer.dynamic_port_range, sizeof(dynamic_port_range) );
@@ -171,6 +174,14 @@ fd_config_fillh( fd_config_t * config ) {
     FD_LOG_ERR(( "configuration specifies invalid [tiles.quic.vote_transaction_listen_port] `%hu`. "
                  "This must be outside the dynamic port range `%s`",
                  config->tiles.quic.vote_transaction_listen_port,
+                 config->frankendancer.dynamic_port_range ));
+
+  if( FD_UNLIKELY( config->gossip.public_tpu_quic_port &&
+                   config->gossip.public_tpu_quic_port >= agave_port_min &&
+                   config->gossip.public_tpu_quic_port < agave_port_max ) )
+    FD_LOG_ERR(( "configuration specifies invalid [gossip.public_tpu_quic_port] `%hu`. "
+                 "This must be outside the dynamic port range `%s`",
+                 config->gossip.public_tpu_quic_port,
                  config->frankendancer.dynamic_port_range ));
 
   if( FD_UNLIKELY( config->tiles.shred.shred_listen_port >= agave_port_min &&
@@ -514,9 +525,7 @@ fd_config_validate( fd_config_t const * config ) {
   CFG_HAS_NON_ZERO( tiles.netlink.max_routes    );
   CFG_HAS_NON_ZERO( tiles.netlink.max_neighbors );
 
-  CFG_HAS_NON_ZERO( tiles.quic.regular_transaction_listen_port );
-  CFG_HAS_NON_ZERO( tiles.quic.quic_transaction_listen_port );
-  CFG_HAS_NON_ZERO( tiles.quic.vote_transaction_listen_port );
+  /* quic transaction ports may be zero to disable local listeners */
   CFG_HAS_NON_ZERO( tiles.quic.max_concurrent_connections );
   CFG_HAS_NON_ZERO( tiles.quic.txn_reassembly_count );
   CFG_HAS_NON_ZERO( tiles.quic.max_concurrent_handshakes );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -213,6 +213,7 @@ struct fd_config {
     ulong         resolved_entrypoints_cnt; /* ??? why during config ... */
     fd_ip4_port_t resolved_entrypoints[ FD_CONFIG_GOSSIP_ENTRYPOINTS_MAX ];
     ushort port;
+    ushort public_tpu_quic_port; /* advertise this TPU QUIC port instead of the listen port when nonzero */
   } gossip;
 
   struct {

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -127,6 +127,7 @@ fd_config_extract_pod( uchar *       pod,
 
   CFG_POP_ARRAY( cstr,   gossip.entrypoints                               );
   CFG_POP      ( ushort, gossip.port                                      );
+  CFG_POP      ( ushort, gossip.public_tpu_quic_port                      );
 
   CFG_POP      ( ushort, consensus.expected_shred_version                 );
 


### PR DESCRIPTION
## Summary
- expose `public_tpu_quic_port` in configuration
- advertise the override in gossip topology
- allow disabling local TPU ports and validate new field

## Testing
- `make run-unit-test` *(fails: Not enough memory)*

------
https://chatgpt.com/codex/tasks/task_e_684ac0aa31f483278f167561079dbcea