### PR TITLE
Add public TPU Quic port option

### DIFF
--- a/src/app/fdctl/config/default.toml
+++ b/src/app/fdctl/config/default.toml
@@ -1010,6 +1010,10 @@ dynamic_port_range = "8900-9000"
         # transaction_listen_port.
         quic_transaction_listen_port = 9007
 
+        # Optional: Override the TPU QUIC port advertised in gossip.
+        # When set to 0, the quic_transaction_listen_port is advertised.
+        public_tpu_quic_port = 0
+
         # Maximum number of simultaneous QUIC connections which can be
         # open.  New connections which would exceed this limit will not
         # be accepted.

--- a/src/app/firedancer/topology.c
+++ b/src/app/firedancer/topology.c
@@ -806,7 +806,9 @@ fd_topo_initialize( config_t * config ) {
         FD_LOG_ERR(( "shred_listen_port in the config must not be greater than %hu", (ushort)(USHORT_MAX-6) ));
       tile->gossip.expected_shred_version = config->consensus.expected_shred_version;
       tile->gossip.tpu_port             = config->tiles.quic.regular_transaction_listen_port;
-      tile->gossip.tpu_quic_port        = config->tiles.quic.quic_transaction_listen_port;
+      tile->gossip.tpu_quic_port        = config->tiles.quic.public_tpu_quic_port
+                                          ? config->tiles.quic.public_tpu_quic_port
+                                          : config->tiles.quic.quic_transaction_listen_port;
       tile->gossip.tpu_vote_port        = config->tiles.quic.regular_transaction_listen_port; /* TODO: support separate port for tpu vote */
       tile->gossip.repair_serve_port    = config->tiles.repair.repair_serve_listen_port;
       tile->gossip.entrypoints_cnt      = fd_ulong_min( config->gossip.resolved_entrypoints_cnt, FD_TOPO_GOSSIP_ENTRYPOINTS_MAX );

--- a/src/app/shared/fd_config.h
+++ b/src/app/shared/fd_config.h
@@ -337,6 +337,7 @@ struct fd_config {
     struct {
       ushort regular_transaction_listen_port;
       ushort quic_transaction_listen_port;
+      ushort public_tpu_quic_port;
 
       uint txn_reassembly_count;
       uint max_concurrent_connections;

--- a/src/app/shared/fd_config_parse.c
+++ b/src/app/shared/fd_config_parse.c
@@ -300,6 +300,7 @@ fdctl_pod_to_cfg( config_t * config,
 
   CFG_POP      ( ushort, tiles.quic.regular_transaction_listen_port       );
   CFG_POP      ( ushort, tiles.quic.quic_transaction_listen_port          );
+  CFG_POP      ( ushort, tiles.quic.public_tpu_quic_port                  );
   CFG_POP      ( uint,   tiles.quic.txn_reassembly_count                  );
   CFG_POP      ( uint,   tiles.quic.max_concurrent_connections            );
   CFG_POP      ( uint,   tiles.quic.max_concurrent_handshakes             );


### PR DESCRIPTION
## Summary
- allow overriding the TPU Quic port that Firedancer advertises

## Testing
- `make run-unit-test` *(fails: Not enough memory)*
- `make -j4` *(fails: build errors)*

------
https://chatgpt.com/codex/tasks/task_e_684ad688618c8327a84e7ca985d2a9de